### PR TITLE
MySQL Database initialization fix

### DIFF
--- a/audino/docker-compose.prod.yml
+++ b/audino/docker-compose.prod.yml
@@ -52,6 +52,7 @@ services:
       - rclone
     networks:
       - backend-network
+    command: --init-file=/mysql/create_database.sql --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
 
   redis:
     build: ./redis

--- a/audino/mysql/Dockerfile
+++ b/audino/mysql/Dockerfile
@@ -107,7 +107,7 @@ RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 3306 33060
+USER root
+CMD ["mysqld"]
 
-#CMD ["mysqld"]
-
-CMD ["/start.sh"]
+#CMD ["/start.sh"]

--- a/audino/mysql/crontab
+++ b/audino/mysql/crontab
@@ -1,2 +1,2 @@
-0 0 * * * mkdir -p /mnt/backup/`date +\%Y\%m\%d` && cp -R /var/lib/mysql /mnt/backup/`date +\%Y\%m\%d` >> /var/log/cron.log 2>&1
+* * * * * mkdir -p /mnt/backup/`date +\%Y\%m\%d` && cp -R /var/lib/mysql /mnt/backup/`date +\%Y\%m\%d` >> /var/log/cron.log 2>&1
 #emptyline required for cron to run properly

--- a/audino/mysql/start.sh
+++ b/audino/mysql/start.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
-
+#!/usr/bin/env bash-
+echo "You are login as: `whoami`"
 cron;
-mysqld --user=root --init-file=/mysql/create_database.sql --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+#mysqld --user=root --init-file=/mysql/create_database.sql --character-set-server=utf8mb4 --collation-server=utf8mb4_bin


### PR DESCRIPTION
This attempts to fix the "table.users not found error" shown while running the production docker containers. The issue was mysql was not properly setting itself up in it's docker container. This bring over the code found at: https://github.com/docker-library/mysql/tree/master/5.7 in order to make sure that mysql is able to start correctly and we can set up rclone in a Dockerfile. This does mean that we should watch up for updates on this github repo as we will need to manually update this code until we can figure out how to both run the mysql image and build rclone via dockerfile or script. 