### PR TITLE
Hotfix 3: Fixed mutli-select annotations

### DIFF
--- a/audino/backend/routes/JsonLabelsToCsv.py
+++ b/audino/backend/routes/JsonLabelsToCsv.py
@@ -1,5 +1,7 @@
 import json
 import csv
+from pprint import pprint
+
 
 def fileWrapperForJson(filename):
     with open(filename, 'r') as f:
@@ -28,9 +30,6 @@ def JsonToCsv(data, filename):
                     label = "NO LABEL"
                 else:
                     label = list(region['annotations'].values())[0]['values']['value']
-                print(region)
-                print(type(segments))
-                print(label)
                 last_modified = region['last_modified']
                 end = region['end_time']
                 start = region['start_time']
@@ -47,26 +46,37 @@ def JsonToText(data):
         clip_length = audio['clip_length']
         original_filename = audio['original_filename']       
         segments = audio['segmentations']
+
         for region in segments:
-            if len(region['annotations']) == 0:
-                label = "NO LABEL"
-            else:
-                label = list(region['annotations'].values())[0]['values']['value']
             end = region['end_time']
             start = region['start_time']
             time_spent = region['time_spent']
-            text = write_row(text, [original_filename, clip_length, start, round((end-start), 4),  sampling_rate, label, time_spent])
-            csv.append([original_filename, clip_length, start, round((end-start), 4),  sampling_rate, label, time_spent])
+            if len(region['annotations']) == 0:
+                label = "NO LABEL"
+                text = write_row(text, [original_filename, clip_length, start, round((end-start), 4),  sampling_rate, label, time_spent])
+                csv.append([original_filename, clip_length, start, round((end-start), 4),  sampling_rate, label, time_spent])
+            else:
+                for labelCate in region['annotations'].values():
+                    print(labelCate)
+                    values = labelCate["values"]
+                    try:
+                        for label in values:
+                            print(label)
+                            label = label['value'] 
+                            text = write_row(text, [original_filename, clip_length, start, round((end-start), 4),  sampling_rate, label, time_spent])
+                            csv.append([original_filename, clip_length, start, round((end-start), 4),  sampling_rate, label, time_spent])
+                    except:
+                        label = values['value'] 
+                        text = write_row(text, [original_filename, clip_length, start, round((end-start), 4),  sampling_rate, label, time_spent])
+                        csv.append([original_filename, clip_length, start, round((end-start), 4),  sampling_rate, label, time_spent])
     return text, csv
 
 def write_row(text, row):
-    print(row)
-    print(len(row))
     for i in range(len(row)):
-        print(i)
         text = text + str(row[i])
         if (i == (len(row) - 1)):
             text = text + "\n"
         else:
             text = text + ","
     return text
+

--- a/audino/backend/routes/data.py
+++ b/audino/backend/routes/data.py
@@ -87,7 +87,9 @@ def generate_segmentation(
 
         if isinstance(label_values, list):
             for val_id in label_values:
-
+                app.logger.info(val_id)
+                app.logger.info(label_values)
+                app.logger.info("===================")
                 value = LabelValue.query.filter_by(
                     id=int(val_id), label_id=int(label.id)
                 ).first()

--- a/audino/backend/routes/projects.py
+++ b/audino/backend/routes/projects.py
@@ -541,11 +541,11 @@ def get_segmentations_for_data(project_id, data_id):
                     values[value.label.name] = {
                         "label_id": value.label.id,
                         "values": []
-                        if value.label.label_type.type == "multiselect"
+                        if value.label.label_type.type == "Multi-select"
                         else None,
                     }
 
-                if value.label.label_type.type == "multiselect":
+                if value.label.label_type.type == "Multi-select":
                     values[value.label.name]["values"].append(value.id)
                 else:
                     values[value.label.name]["values"] = value.id
@@ -783,11 +783,11 @@ def get_project_annotations(project_id):
                         values[value.label.name] = {
                             "id": value.label.id,
                             "values": []
-                            if value.label.label_type.type == "multiselect"
+                            if value.label.label_type.type == "Multi-select"
                             else None,
                         }
 
-                    if value.label.label_type.type == "multiselect":
+                    if value.label.label_type.type == "Multi-select":
                         values[value.label.name]["values"].append(
                             {"id": value.id, "value": value.value}
                         )
@@ -801,9 +801,6 @@ def get_project_annotations(project_id):
 
                 data_dict["segmentations"].append(segmentation_dict)
             annotations.append(data_dict)
-        text, csv =  JsonLabelsToCsv.JsonToText(annotations)
-        app.logger.info(f'{type(text)}, {text}')
-        json_return = {'annotations': str(text)}
         app.logger.info("could do this, error isn't here")
     except Exception as e:
         message = "Error fetching annotations for project"
@@ -811,6 +808,8 @@ def get_project_annotations(project_id):
         app.logger.error(e)
         return jsonify(message=message, type="FETCH_ANNOTATIONS_FAILED"), 500
     if ((download_csv) == "true"):
+        text, csv =  JsonLabelsToCsv.JsonToText(annotations)
+        app.logger.info(f'{type(text)}, {text}')
         annotations_to_download = csv
         app.logger.info("here: ", annotations_to_download)
     else:

--- a/audino/frontend/src/components/annotate_c.js
+++ b/audino/frontend/src/components/annotate_c.js
@@ -631,7 +631,7 @@ class Annotate_C extends React.Component {
   handleLabelChange(key, e) {
     const { selectedSegment, labels } = this.state;
     selectedSegment.data.annotations = selectedSegment.data.annotations || {};
-    if (labels[key]["type"] === "multiselect") {
+    if (labels[key]["type"] === "Multi-select") {
       selectedSegment.data.annotations[key] = {
         label_id: labels[key]["label_id"],
         values: Array.from(e.target.selectedOptions, (option) => option.value),
@@ -994,7 +994,7 @@ class Annotate_C extends React.Component {
                             className="form-control"
                             name={key}
                             multiple={
-                              value["type"] === "multiselect" ? true : false
+                              value["type"] === "Multi-select" ? true : false
                             }
                             value={
                               (selectedSegment &&
@@ -1003,12 +1003,12 @@ class Annotate_C extends React.Component {
                                 selectedSegment.data.annotations[key][
                                   "values"
                                 ]) ||
-                              (value["type"] === "multiselect" ? [] : "")
+                              (value["type"] === "Multi-select" ? [] : "")
                             }
                             onChange={(e) => this.handleLabelChange(key, e)}
                             ref={(el) => (this.labelRef[key] = el)}
                           >
-                            {value["type"] !== "multiselect" ? (
+                            {value["type"] !== "Multi-select" ? (
                               <option value="-1">Choose Label Type</option>
                             ) : null}
                             {value["values"].map((val) => {


### PR DESCRIPTION
I noticed that mutli-select annotations weren't behaving normally so I look into it

Basically the type name of mutli-select annotations was "Mutli-select" but the code refer to them as "mutliselect" so nothing worked.

Additionally I added mutli-select annotation support to csv downloads. This will be a handy fix for mixed-species labels. 

To test:
- Create a new project, create 2 label categories - one select and one mutliselect
- annotate labels using both labels types
- Download annotations as both json and csv, make sure they are giving the same info without crashing
-  ~~Also test on a local production branch~~
- code should work without needing to bring down docker volumes