### PR TITLE
Hotfix 1.0.1: Force Next/Previous + Frontend Production Update Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project, Pyrenote, creates moment to moment or strong labels for audio data. Pyrenote and much of this README are based on heavily on [Audino](https://github.com/midas-research/audino) as well as [Wavesufer.js](https://github.com/katspaugh/wavesurfer.js). The name is a combination of Py, Lyrebird, and note (such as making a note on a label).
 
- If you want to use Pyrenote, use the fallowing to get started!
+ If you want to use Pyrenote, use the following to get started!
 
 **NOTE** Before making any changes to the code, make sure to create a branch to safetly make changes. Never commit directly to main.
 **Read github_procedures.md for more detailed information before contributing to the repo** 

--- a/audino/README.md
+++ b/audino/README.md
@@ -121,7 +121,7 @@ To access the site, sign in with the username of **admin** and password of **pas
 After creating a project, get the api key by returning to the admin portal. You can use the api key to add data to a project. Create a new terminal (while docker is running the severs) and cd into audino/backend/scripts. Here use the fallowing command:
 
 ```
-python upload_mass.py  --username admin.test  --is_marked_for_review True --audio_file C:\REPLACE\THIS\WITH\FOLDER\PATH\TO\AUDIO\DATA --host localhost 
+python upload_mass.py  --username admin  --is_marked_for_review True --audio_file C:\REPLACE\THIS\WITH\FOLDER\PATH\TO\AUDIO\DATA --host localhost 
 --port 5000 --api_key REPLACE_THIS_WITH_API_KEY
 ```
 Make sure to have a folder with the audio data ready to be added. For testing purposes, get a folder with about 20 clips. 

--- a/audino/frontend/Dockerfile
+++ b/audino/frontend/Dockerfile
@@ -7,4 +7,14 @@ COPY . /app/frontend
 RUN npm install -g npm@6.14.4
 RUN npm install
 
-RUN npm run build
+#RUN npm run build
+#
+#RUN ls /app/frontend/build/static/js/
+
+ADD ./test.sh /
+
+RUN chmod +x /test.sh
+
+COPY test.sh /usr/local/bin/
+
+ENTRYPOINT ["/test.sh"]

--- a/audino/frontend/src/components/navbutton.js
+++ b/audino/frontend/src/components/navbutton.js
@@ -6,7 +6,7 @@ const NavButton = props => {
 
   // Go to the next audio recording
   const handleNextClip = (forceNext = false) => {
-    props.save(annotate);
+    annotate.handleAllSegmentSave();
     const {
       previous_pages,
       num_of_prev,
@@ -19,7 +19,7 @@ const NavButton = props => {
     } = annotate.state;
 
     let success = true;
-    success = annotate.checkForSave(success, forceNext);
+    success = annotate.checkForSave(success, forceNext, 'next');
     if (!success) {
       return;
     }
@@ -55,11 +55,11 @@ const NavButton = props => {
   };
 
   // Go to previous audio recording
-  const handlePreviousClip = (forceNext = false) => {
+  const handlePreviousClip = (forcePrev = false) => {
     annotate.handleAllSegmentSave();
     const { previous_pages, num_of_prev } = annotate.state;
     let success = true;
-    success = annotate.checkForSave(success, forceNext);
+    success = annotate.checkForSave(success, forcePrev, 'previous');
     if (success) {
       if (num_of_prev > 0) {
         const page_num = num_of_prev - 1;
@@ -91,10 +91,48 @@ const NavButton = props => {
     );
   };
 
+  const checkForce = () => {
+    const unsaved = annotate.state.errorUnsavedMessage;
+    const dir = annotate.state.direction;
+    let func;
+    let text;
+    if (dir === 'next') {
+      func = handleNextClip;
+      text = 'Force Next';
+    }
+    if (dir === 'previous') {
+      func = handlePreviousClip;
+      text = 'Force Prev';
+    }
+    if (unsaved) {
+      return (
+        <div className="buttons-container-item" style={{ margin: 'auto', marginBottom: '2%' }}>
+          <Button
+            size="lg"
+            type="danger"
+            disabled={annotate.state.isSegmentSaving}
+            onClick={() => func(true)}
+            isSubmitting={annotate.state.isSegmentSaving}
+            text={text}
+          />
+        </div>
+      );
+    }
+    return null;
+  };
+
   return (
-    <div className="buttons-container">
-      {renderNavButtons('previous', () => handlePreviousClip())}
-      {renderNavButtons('next', () => handleNextClip())}
+    <div>
+      <div className="buttons-container">
+        {renderNavButtons('previous', () => handlePreviousClip())}
+        {renderNavButtons('next', () => handleNextClip())}
+      </div>
+      <div
+        className="buttons-container"
+        // style={{ margin: 'auto', marginBottom: '2%' }}
+      >
+        {checkForce()}
+      </div>
     </div>
   );
 };

--- a/audino/frontend/src/pages/annotate.js
+++ b/audino/frontend/src/pages/annotate.js
@@ -333,7 +333,7 @@ class Annotate extends React.Component {
       if (segment.saved === false && !forceClip) {
         if (segment.data.annotations == null) {
           this.setState({
-            errorUnsavedMessage: `There regions without a label! You can't leave yet! If you are sure, click "force ${dir}"`
+            errorUnsavedMessage: `There are regions without a label! You can't leave yet! If you are sure, click "force ${dir}"`
           });
           success = false;
         }

--- a/audino/frontend/src/pages/annotate.js
+++ b/audino/frontend/src/pages/annotate.js
@@ -42,7 +42,8 @@ class Annotate extends React.Component {
       previous_pages: [],
       num_of_prev: 0,
       numpage: 5,
-      path: window.location.href.substring(0, index)
+      path: window.location.href.substring(0, index),
+      direction: null
     };
     this.lastTime = 0;
     this.labelRef = {};
@@ -325,14 +326,14 @@ class Annotate extends React.Component {
     });
   }
 
-  checkForSave(success, forceNext) {
+  checkForSave(success, forceClip, dir) {
     const { wavesurfer } = this.state;
+    this.setState({ direction: dir });
     Object.values(wavesurfer.regions.list).forEach(segment => {
-      if (segment.saved === false && !forceNext) {
+      if (segment.saved === false && !forceClip) {
         if (segment.data.annotations == null) {
           this.setState({
-            errorUnsavedMessage:
-              'There regions without a label! You can\'t leave yet! If you are sure, click "force next"'
+            errorUnsavedMessage: `There regions without a label! You can't leave yet! If you are sure, click "force ${dir}"`
           });
           success = false;
         }
@@ -504,22 +505,6 @@ class Annotate extends React.Component {
                   </label>
                 </div>
               </div>
-
-              {errorUnsavedMessage && (
-                <div
-                  className="buttons-container-item"
-                  style={{ margin: 'auto', marginBottom: '2%' }}
-                >
-                  <Button
-                    size="lg"
-                    type="danger"
-                    disabled={isSegmentSaving}
-                    onClick={() => this.handleNextClip(true)}
-                    isSubmitting={isSegmentSaving}
-                    text="Force Next"
-                  />
-                </div>
-              )}
               <NavButton save={this.handleAllSegmentSave} annotate={this} />
             </div>
           </div>

--- a/audino/frontend/test.sh
+++ b/audino/frontend/test.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npm run build


### PR DESCRIPTION
Fixed:
- Bug where when clicking force next, code is unable to call the method handleNextClip() as it is a const variable in NavButtons (#141)
- Frontend does not update to newest code changes when running production builds (#142)
- Fixed typo on readme and forced next message

Solution:
- Move force code to `navbuttons.js` from `annotate.js`
- React Production build of frontend does now updates to newest changes

Added:
- Forced previous button (#107)
- Swap between forced previous and forced next depending on what buttons users presses

Closes #119
Closes #107
Closes #141 
Closes #142