### PR TITLE
Handler for Access Token Errors

### DIFF
--- a/audino/frontend/src/app.js
+++ b/audino/frontend/src/app.js
@@ -103,6 +103,12 @@ class App extends React.Component {
               store.set('isUserCreatingAccount', false);
             }
           }
+          if (error.response.status === 422) {
+            localStorage.removeItem('access_token')
+            history.push('/');
+            store.set('isUserLoggedIn', false);
+            store.set('isUserCreatingAccount', false);
+          }
         });
     } else {
       store.set('isUserCreatingAccount', true);

--- a/audino/frontend/src/pages/index.js
+++ b/audino/frontend/src/pages/index.js
@@ -7,5 +7,4 @@ import Home from './home';
 import Labels from './labels';
 import LabelValues from './labelValues';
 import CreateUser from './createUser';
-import Access_Token_Handle from './access_token_handler'
 export { Admin, Dashboard, Error, Home, Labels, LabelValues, Data, Annotate, CreateUser};

--- a/audino/frontend/src/pages/index.js
+++ b/audino/frontend/src/pages/index.js
@@ -7,5 +7,5 @@ import Home from './home';
 import Labels from './labels';
 import LabelValues from './labelValues';
 import CreateUser from './createUser';
-
-export { Admin, Dashboard, Error, Home, Labels, LabelValues, Data, Annotate, CreateUser };
+import Access_Token_Handle from './access_token_handler'
+export { Admin, Dashboard, Error, Home, Labels, LabelValues, Data, Annotate, CreateUser, Access_Token_Handle };

--- a/audino/frontend/src/pages/index.js
+++ b/audino/frontend/src/pages/index.js
@@ -8,4 +8,4 @@ import Labels from './labels';
 import LabelValues from './labelValues';
 import CreateUser from './createUser';
 import Access_Token_Handle from './access_token_handler'
-export { Admin, Dashboard, Error, Home, Labels, LabelValues, Data, Annotate, CreateUser, Access_Token_Handle };
+export { Admin, Dashboard, Error, Home, Labels, LabelValues, Data, Annotate, CreateUser};


### PR DESCRIPTION
Handles issues where the access token or JWT_ACCESS_TOKEN changes and the frontend doesn't update. Basically whenever the user's account does not properly authenticate user, it will log them out and delete the user's current access token.

Changes:
- Delete access token and log out on 422 error on the authentication check

Test:
- Change your access token by changing your .env file

Close (#132) 