### PR TITLE
Add enter handlers to various textboxes in admin portal

### DIFF
--- a/audino/frontend/src/containers/forms/editProjectForm.js
+++ b/audino/frontend/src/containers/forms/editProjectForm.js
@@ -85,6 +85,12 @@ class EditProjectForm extends React.Component {
       });
   }
 
+  handleEnter(e) {
+    if(e.key === 'Enter') {
+      this.handleProjectCreation(e)        
+    }
+  }
+
   resetState() {
     this.setState(this.initialState);
   }
@@ -112,6 +118,7 @@ class EditProjectForm extends React.Component {
                 autoFocus
                 required
                 onChange={e => this.handleProjectNameChange(e)}
+                onKeyDown={e => this.handleEnter(e)}
               />
             </div>
             <div className="form-row">


### PR DESCRIPTION
Same with create_project, other text boxes in admin portal need enter handlers, so I'm adding that in

Currently added with enter handling
- edit project

TODO:
- check all text entry on admin portal