### PR TITLE
Set Individual projects as example rather than hardcode

### DIFF
--- a/audino/backend/models.py
+++ b/audino/backend/models.py
@@ -229,12 +229,20 @@ class Project(db.Model):
         onupdate=db.func.utc_timestamp(),
     )
 
+    is_example = db.Column(
+        "is_example", db.Boolean(), nullable=True, default=False
+    )
+
     users = db.relationship(
         "User", secondary=user_project_table, back_populates="projects"
     )
     data = db.relationship("Data", backref="Project")
     labels = db.relationship("Label", backref="Project")
     creator_user = db.relationship("User")
+
+    def set_is_example(self, is_example):
+        self.is_example = is_example
+        app.logger.info(self.is_example)
 
     def set_name(self, newUsername):
         self.name = newUsername

--- a/audino/backend/routes/__init__.py
+++ b/audino/backend/routes/__init__.py
@@ -21,7 +21,7 @@ from .projects import (
     fetch_project,
     edit_project,
     update_project_users,
-    give_users_examples,
+    give_users_examples_json,
     add_label_to_project,
     get_label_for_project,
     update_label_for_project,

--- a/audino/backend/routes/current_user.py
+++ b/audino/backend/routes/current_user.py
@@ -4,7 +4,7 @@ import uuid
 from flask import jsonify, flash, redirect, url_for, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from werkzeug.urls import url_parse
-
+from .projects import give_users_examples
 from backend import app, db
 from backend.models import Project, User, Data, Segmentation
 
@@ -19,6 +19,7 @@ def fetch_current_user_projects():
     try:
         request_user = User.query.filter_by(username=identity["username"]
                                             ).first()
+        give_users_examples(request_user.id)
         response = list(
             [
                 {

--- a/audino/backend/routes/projects.py
+++ b/audino/backend/routes/projects.py
@@ -138,6 +138,7 @@ def fetch_project(project_id):
         jsonify(
             project_id=project.id,
             name=project.name,
+            is_example=project.is_example,
             users=users,
             labels=labels,
             api_key=project.api_key,
@@ -151,7 +152,6 @@ def fetch_project(project_id):
 @api.route("/projects/<int:project_id>", methods=["PATCH"])
 @jwt_required
 def edit_project(project_id):
-    app.logger.info("hello")
     identity = get_jwt_identity()
     request_user = User.query.filter_by(username=identity["username"]).first()
     is_admin = True if request_user.role.role == "admin" else False
@@ -162,7 +162,13 @@ def edit_project(project_id):
     try:
         project = Project.query.get(project_id)
         newUserName = request.json.get("name", None)
-        project.set_name(newUserName)
+        is_example = request.json.get("is_example", None)
+        if (newUserName is not None or newUserName == ''):
+            project.set_name(newUserName)
+
+        if (is_example is not None):
+            app.logger.info(is_example == 'true')
+            project.set_is_example(is_example == 'true')
         # user = User.query.get(user_id)
         # user.set_role(role_id)
         # user.set_username(newUserName)
@@ -183,6 +189,7 @@ def edit_project(project_id):
         jsonify(
             project_id=project.id,
             name=project.name,
+            message="Successful edit"
         ),
         200,
     )
@@ -250,21 +257,18 @@ def update_project_users(project_id):
     )
 
 
-@api.route("/projects/example", methods=["PATCH"])
-def give_users_examples():
-    user_id = request.json.get("users")
-    app.logger.info(f"{user_id}")
-    for project_id in [3, 4, 5]:
+def find_example_projects():
+    return Project.query.filter(Project.is_example == (True)).all()
+
+
+def give_users_examples(user_id):
+    for project in find_example_projects():
         try:
-            project = Project.query.get(project_id)
-            # TODO: Decide whether to give creator of project access
-            # project.users.append(request_user)
             if project is None:
-                app.logger.info(f"{project_id} is null")
+                app.logger.info(f"{project} is null")
                 continue
             final_users = [user for user in project.users]
-            user = User.query.filter_by(username=user_id).first()
-            app.logger.info(f"{user.username}")
+            user = User.query.filter_by(id=user_id).first()
             if user not in project.users:
                 final_users.append(user)
 
@@ -279,7 +283,7 @@ def give_users_examples():
             app.logger.error(e)
             return (
                 jsonify(
-                    message=f"Error adding users to project: {project_id}",
+                    message=f"Error adding users to project: {project.id}",
                     type="USERS_ASSIGNMENT_FAILED",
                 ),
                 500,
@@ -293,6 +297,14 @@ def give_users_examples():
         ),
         200,
     )
+
+
+@api.route("/projects/example", methods=["PATCH"])
+def give_users_examples_json():
+    user_id = request.json.get("users")
+    user = User.query.filter_by(username=user_id).first()
+    app.logger.info(f"{user_id}")
+    return give_users_examples(user.id)
 
 
 @api.route("/projects/<int:project_id>/labels", methods=["POST"])

--- a/audino/frontend/src/components/navbutton.js
+++ b/audino/frontend/src/components/navbutton.js
@@ -69,7 +69,7 @@ const NavButton = props => {
         localStorage.setItem('count', JSON.stringify(page_num));
         window.location.href = previous;
       } else {
-        annotate.setState({errorMessage: "no more previous clips"})
+        console.warn('You have hit the end of the clips you have last seen');
       }
     }
   };

--- a/audino/frontend/src/components/navbutton.js
+++ b/audino/frontend/src/components/navbutton.js
@@ -69,7 +69,7 @@ const NavButton = props => {
         localStorage.setItem('count', JSON.stringify(page_num));
         window.location.href = previous;
       } else {
-        console.warn('You have hit the end of the clips you have last seen');
+        annotate.setState({errorMessage: "no more previous clips"})
       }
     }
   };

--- a/audino/frontend/src/containers/forms/editProjectForm.js
+++ b/audino/frontend/src/containers/forms/editProjectForm.js
@@ -15,7 +15,8 @@ class EditProjectForm extends React.Component {
       errorMessage: '',
       successMessage: '',
       isSubmitting: false,
-      url: `/api/projects/${projectId}`
+      url: `/api/projects/${projectId}`,
+      isMarkedExample: false,
     };
 
     this.state = { ...this.initialState };
@@ -29,8 +30,9 @@ class EditProjectForm extends React.Component {
     })
       .then(response => {
         if (response.status === 200) {
-          const { name } = response.data;
-          this.setState({ name });
+          const { name, is_example } = response.data;
+          console.log(is_example)
+          this.setState({ name, isMarkedExample: is_example });
         }
       })
       .catch(error => {
@@ -45,35 +47,27 @@ class EditProjectForm extends React.Component {
     this.setState({ name: e.target.value });
   }
 
+  handleMarkedExampleChange(e) {
+    this.setState({isMarkedExample: e.target.value})
+  }
+
   handleProjectCreation(e) {
     e.preventDefault();
 
     this.setState({ isSubmitting: true });
 
-    const { name, url } = this.state;
-
-    if (!name || name === '') {
-      this.setState({
-        isSubmitting: false,
-        errorMessage: 'Please enter a valid project name!',
-        successMessage: null
-      });
-      return;
-    }
+    const { name, url, isMarkedExample } = this.state;
 
     axios({
       method: 'patch',
       url,
       data: {
-        name
+        name,
+        is_example: isMarkedExample
       }
     })
       .then(response => {
-        this.resetState();
-        this.form.reset();
-        if (response.status === 201) {
-          this.setState({ successMessage: response.data.message });
-        }
+          this.setState({ successMessage: response.data.message, isSubmitting: false, });
       })
       .catch(error => {
         console.error(error.response);
@@ -90,7 +84,7 @@ class EditProjectForm extends React.Component {
   }
 
   render() {
-    const { isSubmitting, errorMessage, successMessage, projectId } = this.state;
+    const { isSubmitting, errorMessage, successMessage, projectId, isMarkedExample, name } = this.state;
     return (
       <div className="container h-75 text-center">
         <div className="row h-100 justify-content-center align-items-center">
@@ -107,22 +101,26 @@ class EditProjectForm extends React.Component {
               <input
                 type="text"
                 className="form-control"
-                id="username"
-                placeholder=""
-                value={projectId}
-                autoFocus
-                required
-                disabled
-              />
-              <input
-                type="text"
-                className="form-control"
                 id="project_name"
-                placeholder="Project Name"
+                placeholder={name}
                 autoFocus
                 required
                 onChange={e => this.handleProjectNameChange(e)}
               />
+            </div>
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                id="isExample"
+                value
+                checked={isMarkedExample}
+                onChange={e => this.handleMarkedExampleChange(e)}
+                //disabled={isMarkedForReviewLoading}
+              />
+              <label className="form-check-label" htmlFor="isMarkedForReview">
+                Mark is Example Project
+              </label>
             </div>
             <div className="form-row">
               <div className="form-group col">

--- a/audino/frontend/src/containers/forms/editProjectForm.js
+++ b/audino/frontend/src/containers/forms/editProjectForm.js
@@ -48,7 +48,7 @@ class EditProjectForm extends React.Component {
   }
 
   handleMarkedExampleChange(e) {
-    this.setState({isMarkedExample: e.target.value})
+    this.setState({isMarkedExample: !e.target.value})
   }
 
   handleProjectCreation(e) {


### PR DESCRIPTION
Basically create toggle in the editProjectForm.js that when switched on allows any user to access the project without any admin's explicit permission


To Test
- Create a new user
- See that projects are not given to new user
- return to admin
- edit a project to have example permissions
- Return to new user and see they now can access the project
- return to admin
- edit same project to remove example permissions
- return to new user
- see that they cannot access the project anymore