### PR TITLE
Cut refresh on annotate.js

### DIFF
--- a/audino/frontend/src/components/annotate/navbutton.js
+++ b/audino/frontend/src/components/annotate/navbutton.js
@@ -44,10 +44,10 @@ const NavButton = props => {
 
     if (num_of_prev < previous_pages.length - 1) {
       localStorage.setItem('count', JSON.stringify(next_page_num));
-      window.location.href = previous_pages[next_page_num];
+      annotate.nextPage(previous_pages[next_page_num])
       return;
     }
-    previous_pages[num_of_prev] = window.location.href;
+    previous_pages[num_of_prev] = dataId;
     localStorage.setItem('previous_links', JSON.stringify(previous_pages));
     localStorage.setItem('count', JSON.stringify(next_page_num));
 
@@ -57,8 +57,7 @@ const NavButton = props => {
       if (data[key].data_id === dataId) {
         try {
           newPageData = data[key + 1];
-          const url = `/projects/${projectId}/data/${newPageData.data_id}/annotate`;
-          /// projects
+          console.log(data[key], data[key + 1])
           annotate.nextPage(newPageData.data_id)
           //window.location.href = path + url;
         } catch (z) {
@@ -83,10 +82,10 @@ const NavButton = props => {
       if (num_of_prev > 0) {
         const page_num = num_of_prev - 1;
         const previous = previous_pages[page_num];
-        previous_pages[num_of_prev] = window.location.href;
+        previous_pages[num_of_prev] = dataId;
         localStorage.setItem('previous_links', JSON.stringify(previous_pages));
         localStorage.setItem('count', JSON.stringify(page_num));
-        window.location.href = previous;
+        annotate.nextPage(previous)
       } else {
         console.warn('You have hit the end of the clips you have last seen');
         window.location.href = `${path}/projects/${projectId}/data`;

--- a/audino/frontend/src/components/annotate/navbutton.js
+++ b/audino/frontend/src/components/annotate/navbutton.js
@@ -59,10 +59,12 @@ const NavButton = props => {
           newPageData = data[key + 1];
           const url = `/projects/${projectId}/data/${newPageData.data_id}/annotate`;
           /// projects
-          window.location.href = path + url;
+          annotate.nextPage(newPageData.data_id)
+          //window.location.href = path + url;
         } catch (z) {
           if (next_data_id && data[0].data_id !== next_data_id) {
-            window.location.href = next_data_url;
+            annotate.nextPage(next_data_id)
+            //window.location.href = next_data_url;
           } else {
             window.location.href = `${path}/projects/${projectId}/data`;
           }

--- a/audino/frontend/src/components/annotate/navbutton.js
+++ b/audino/frontend/src/components/annotate/navbutton.js
@@ -75,7 +75,7 @@ const NavButton = props => {
   // Go to previous audio recording
   const handlePreviousClip = (forcePrev = false) => {
     handleAllSegmentSave(annotate);
-    const { previous_pages, num_of_prev, path, projectId } = annotate.state;
+    const { previous_pages, num_of_prev, path, projectId, dataId } = annotate.state;
     let success = true;
     success = checkForSave(success, forcePrev, 'previous');
     if (success) {

--- a/audino/frontend/src/pages/annotate.js
+++ b/audino/frontend/src/pages/annotate.js
@@ -241,16 +241,17 @@ class Annotate extends React.Component {
 
   nextPage(nextDataId) {
     const {wavesurfer, projectId} = this.state
-    wavesurfer.destroy()
     console.log(nextDataId)
-    this.setState()
     let newState =  this.initalState
     newState["labelsUrl"] =  `/api/projects/${projectId}/labels`
     newState["dataUrl"] = `/api/projects/${projectId}/data/${nextDataId}`
     newState["segmentationUrl"] =  `/api/projects/${projectId}/data/${nextDataId}/segmentations`
     newState["dataId"] = nextDataId
-    this.setState(newState)
-    this.componentDidMount()
+    console.log(newState)
+    this.setState(newState, () => {
+      wavesurfer.destroy()
+      this.componentDidMount()
+    })
   }
 
   render() {

--- a/audino/frontend/src/pages/annotate.js
+++ b/audino/frontend/src/pages/annotate.js
@@ -23,7 +23,7 @@ class Annotate extends React.Component {
     const dataId = Number(match.params.dataid);
     const index = window.location.href.indexOf('/projects');
 
-    this.state = {
+    this.initalState = {
       next_data_url: '',
       next_data_id: -1,
       isPlaying: false,
@@ -57,6 +57,7 @@ class Annotate extends React.Component {
       boundingBox: true,
       initWavesurfer: false
     };
+    this.state = this.initalState;
     this.lastTime = 0;
     this.labelRef = {};
     this.UnsavedButton = null;
@@ -124,6 +125,7 @@ class Annotate extends React.Component {
           isDataLoading: false
         });
       });
+      console.log(this.state)
   }
 
   handleAlertDismiss(e) {
@@ -235,6 +237,20 @@ class Annotate extends React.Component {
           errorMessage: error.message.data.message
         });
       });
+  }
+
+  nextPage(nextDataId) {
+    const {wavesurfer, projectId} = this.state
+    wavesurfer.destroy()
+    console.log(nextDataId)
+    this.setState()
+    let newState =  this.initalState
+    newState["labelsUrl"] =  `/api/projects/${projectId}/labels`
+    newState["dataUrl"] = `/api/projects/${projectId}/data/${nextDataId}`
+    newState["segmentationUrl"] =  `/api/projects/${projectId}/data/${nextDataId}/segmentations`
+    newState["dataId"] = nextDataId
+    this.setState(newState)
+    this.componentDidMount()
   }
 
   render() {


### PR DESCRIPTION
Eliminate loading a new page when going to the next / previous audio clip. 

Test:
Previous and next button work normally, ideally everything should load without a refresh. 

Question:
Is it better to a load a new page or just cut that refresh?

Closes #151 