### PR TITLE
Add button for toggling "Add Regions" mode for better annotating experience on touch screens

### DIFF
--- a/audino/frontend/src/components/annotate/annotationWindow.js
+++ b/audino/frontend/src/components/annotate/annotationWindow.js
@@ -6,9 +6,10 @@ import LabelSection from './labelsSection';
 import LabelButton from './labelButtons';
 import RenderingMsg from './renderingMsg';
 import ToggleYesNo from './toggleYesNo';
+import Button from 'react-bootstrap/Button';
 
 const AnnotationWindow = props => {
-  const { annotate } = props;
+  const { annotate, setAddRegionMode } = props;
   const { state } = annotate;
   const {
     isDataLoading,
@@ -17,7 +18,7 @@ const AnnotationWindow = props => {
     successMessage,
     isRendering,
     original_filename,
-    navButtonsEnabled
+    navButtonsEnabled,
   } = state;
 
   return (
@@ -32,7 +33,19 @@ const AnnotationWindow = props => {
           overlay
           callback={e => annotate.handleAlertDismiss(e)}
         />
-        {!isRendering && <div id="filename">{original_filename}</div>}
+        {!isRendering && 
+          <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+            <div style={{flex: 1}}></div>
+            <div id="filename">{original_filename}</div>
+            <div style={{display: 'flex', flex: 1, justifyContent: 'flex-end'}}>
+              {
+                state.addRegionMode 
+                ? <Button id="add-edit-toggle-button" className="addRegion" variant="primary" onClick={() => {setAddRegionMode(!state.addRegionMode)}}>Add Regions: On</Button>
+                : <Button id="add-edit-toggle-button" className="editRegion" variant="secondary" onClick={() => {setAddRegionMode(!state.addRegionMode)}}>Add Regions: Off</Button>
+              }
+            </div>
+          </div>
+        }
 
         <RenderingMsg isRendering={isRendering} />
         <Spectrogram isRendering={isRendering} />

--- a/audino/frontend/src/containers/forms/featureForm.js
+++ b/audino/frontend/src/containers/forms/featureForm.js
@@ -70,7 +70,7 @@ class FeatureForm extends React.Component {
     })
       .then(() => {
         this.setState({
-          successMessage: 'successfully updated features'
+          successMessage: 'Successfully updated features'
         });
       })
       .catch(error => {
@@ -90,7 +90,6 @@ class FeatureForm extends React.Component {
   }
 
   renderFeatureCols(start, end, feature_list) {
-    const { errorMessage, successMessage } = this.state;
     return (
       <div>
         <form
@@ -99,11 +98,6 @@ class FeatureForm extends React.Component {
             width: '25%'
           }}
         >
-          <FormAlerts
-            errorMessage={errorMessage}
-            successMessage={successMessage}
-            callback={e => this.handleAlertDismiss(e)}
-          />
           {feature_list.slice(start, end).map(([key, value]) => {
             return (
               <FeatureChecklist
@@ -121,11 +115,16 @@ class FeatureForm extends React.Component {
   }
 
   render() {
-    const { featuresEnabled } = this.state;
+    const { featuresEnabled, errorMessage, successMessage } = this.state;
     const feature_list = Object.entries(featuresEnabled);
     const numPerCol = feature_list.length / 4;
     return (
       <div>
+        <FormAlerts
+            errorMessage={errorMessage}
+            successMessage={successMessage}
+            callback={e => this.handleAlertDismiss(e)}
+          />
         <div style={{ display: 'table', justifyContent: 'space-evenly', width: '100%' }}>
           {this.renderFeatureCols(0, numPerCol, feature_list)}
           {this.renderFeatureCols(numPerCol * 1, numPerCol * 2, feature_list)}

--- a/audino/frontend/src/pages/annotate.js
+++ b/audino/frontend/src/pages/annotate.js
@@ -54,7 +54,8 @@ class Annotate extends React.Component {
       initWavesurfer: false,
       maxHeight: document.body.offsetHeight,
       disappear: 'sideMenu',
-      showActiveForm: localStorage.getItem('active') == null
+      showActiveForm: localStorage.getItem('active') == null,
+      addRegionMode: true
     };
     this.state = this.initalState;
     this.lastTime = 0;
@@ -226,6 +227,10 @@ class Annotate extends React.Component {
     }
   }
 
+  setAddRegionMode = (addRegionMode) => {
+    this.setState({addRegionMode: addRegionMode})
+  }
+
   render() {
     const { wavesurferMethods, maxHeight, disappear, referenceWindowOn, showActiveForm } =
       this.state;
@@ -263,18 +268,17 @@ class Annotate extends React.Component {
               leftID="leftWindow"
               propertySwapCallabck={() => this.collapseSideBar()}
             />
-
             <span
               className="AnnotationRegion"
               id="leftWindow"
               style={{ float: 'left', flex: '1 1 0%', marginLeft: '2%', marginRight: '2%' }}
             >
-              <AnnotationWindow annotate={this} />
+              <AnnotationWindow annotate={this} setAddRegionMode={this.setAddRegionMode} />
             </span>
           </div>
         ) : (
           <div className="container h-100">
-            <AnnotationWindow annotate={this} />
+            <AnnotationWindow annotate={this} setAddRegionMode={this.setAddRegionMode} />
           </div>
         )}
       </div>

--- a/audino/frontend/src/wavesurfer.js/src/plugin/regions/index.js
+++ b/audino/frontend/src/wavesurfer.js/src/plugin/regions/index.js
@@ -258,6 +258,9 @@ export default class RegionsPlugin {
     };
 
     const eventDown = e => {
+      if (!document.getElementById("add-edit-toggle-button").className.includes("addRegion")) {
+        return;
+      }
       if (e.touches && e.touches.length > 1) {
         return;
       }


### PR DESCRIPTION
Related to #221 

Added a button on the annotations page that allows the user to toggle the ability to add annotations. When the button is set to "Add Regions: On," the user will be able to add and edit annotations. When the button is set to "Add Regions: Off," the user will not be able to add annotations, and can only edit them. 

This improves annotation experience on mobile, where it can be easy to accidentally add an annotation when trying to edit one.

Also fixed alert message for Toggle Features modal so that it only shows up once instead of for all the columns.