### PR TITLE
Add handle for empty cells

### DIFF
--- a/audino/backend/routes/labels.py
+++ b/audino/backend/routes/labels.py
@@ -79,6 +79,8 @@ def add_value_to_label_from_file(label_id):
     app.logger.info(type(file))
     data = file.split("\n")
     for value in data:
+        if value == "":
+            continue
         try:
             value = value.strip(' \t\n\r')
             label_value = LabelValue(value=value, label_id=label_id)

--- a/audino/backend/routes/labels.py
+++ b/audino/backend/routes/labels.py
@@ -74,7 +74,7 @@ def add_value_to_label_from_file(label_id):
             jsonify(message="Please provide a label value!",
                     type="VALUE_MISSING"), 400,)
     app.logger.info("hello")
-    file = file.read().decode("latin-1")
+    file = file.read().decode("utf-8-sig")
     app.logger.info(file)
     app.logger.info(type(file))
     data = file.split("\n")


### PR DESCRIPTION
Added a handler to ignore empty cells in the label csv when uploading a csv create labels.

To Test:
- Upload a csv to a label category with empty cells
- See it work correctly