### PR TITLE
Button to temporarily hide annotations

### DIFF
--- a/audino/frontend/src/components/annotate/annotationWindow.js
+++ b/audino/frontend/src/components/annotate/annotationWindow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { AlertSection } from '../alert';
 import NavButton from './navbutton';
 import Spectrogram from './spectrogram';
@@ -23,6 +23,22 @@ const AnnotationWindow = props => {
   } = state;
 
   const [showAnnotatingRegions, setShowAnnotatingRegions] = useState(true)
+
+  useEffect(() => {
+    if (showAnnotatingRegions) {
+      // set display:none to each annotating region
+      let elems = document.getElementsByClassName("wavesurfer-region")
+      for (let e of elems) {
+        e.style.display = "block"
+      }
+    } else {
+      // set display:block to each annotating region
+      let elems = document.getElementsByClassName("wavesurfer-region")
+      for (let e of elems) {
+        e.style.display = "none"
+      }
+    }
+  }, [showAnnotatingRegions])
 
   return (
     <div>

--- a/audino/frontend/src/components/annotate/annotationWindow.js
+++ b/audino/frontend/src/components/annotate/annotationWindow.js
@@ -26,13 +26,13 @@ const AnnotationWindow = props => {
 
   useEffect(() => {
     if (showAnnotatingRegions) {
-      // set display:none to each annotating region
+      // set display:block to each annotating region
       let elems = document.getElementsByClassName("wavesurfer-region")
       for (let e of elems) {
         e.style.display = "block"
       }
     } else {
-      // set display:block to each annotating region
+      // set display:none to each annotating region
       let elems = document.getElementsByClassName("wavesurfer-region")
       for (let e of elems) {
         e.style.display = "none"

--- a/audino/frontend/src/components/annotate/annotationWindow.js
+++ b/audino/frontend/src/components/annotate/annotationWindow.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useState } from 'react'
 import { AlertSection } from '../alert';
 import NavButton from './navbutton';
 import Spectrogram from './spectrogram';
@@ -21,6 +22,8 @@ const AnnotationWindow = props => {
     navButtonsEnabled,
   } = state;
 
+  const [showAnnotatingRegions, setShowAnnotatingRegions] = useState(true)
+
   return (
     <div>
       <div className="h-100 mt-5 text-center">
@@ -42,6 +45,11 @@ const AnnotationWindow = props => {
                 state.addRegionMode 
                 ? <Button id="add-edit-toggle-button" className="addRegion" variant="primary" onClick={() => {setAddRegionMode(!state.addRegionMode)}}>Add Regions: On</Button>
                 : <Button id="add-edit-toggle-button" className="editRegion" variant="secondary" onClick={() => {setAddRegionMode(!state.addRegionMode)}}>Add Regions: Off</Button>
+              }
+              {
+                showAnnotatingRegions
+                ? <Button id="show-annotating-toggle-button" className="addRegion" variant="primary" onClick={() => {setShowAnnotatingRegions(!showAnnotatingRegions)}}>Show Annotations: On</Button>
+                : <Button id="show-annotating-toggle-button" className="editRegion" variant="secondary" onClick={() => {setShowAnnotatingRegions(!showAnnotatingRegions)}}>Show Annotations: Off</Button>
               }
             </div>
           </div>


### PR DESCRIPTION
Resolves #20 

Added a new button to `annotationWindow.js` which queries for all `wavesurfer-region` elements and sets the `display` style for them accordingly. It might be good to find a better placement for the button.
![image](https://user-images.githubusercontent.com/35547303/197281537-9e4936c9-a12c-420c-aa62-023e646899a7.png)
