### PR TITLE
Added Previous Project button to Nav Bar

### DIFF
--- a/audino/frontend/package.json
+++ b/audino/frontend/package.json
@@ -66,7 +66,7 @@
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-prettier": "^3.4.1",
-    "eslint-plugin-react": "^7.30.1",
+    "eslint-plugin-react": "^7.34.3",
     "prettier": "^2.7.1",
     "pretty-quick": "^2.0.1"
   },

--- a/audino/frontend/src/app.js
+++ b/audino/frontend/src/app.js
@@ -17,6 +17,7 @@ import {
   Data,
   CreateUser
 } from './pages';
+import BackError from './pages/backError'
 import NavBar from './containers/navbar';
 
 const history = createBrowserHistory();
@@ -149,6 +150,7 @@ class App extends React.Component {
               />
               <PublicRoute exact path="/newUser" component={CreateUser} />
               <Route path="/empty" component={null} key="empty" />
+              <PrivateRoute exact path="/projects/NULL/data" component={BackError} />
               <PrivateRoute exact path="/admin" component={Admin} />
               <PrivateRoute exact path="/dashboard" component={Dashboard} />
               <PrivateRoute exact path="/projects/:id/labels" component={Labels} />
@@ -163,7 +165,7 @@ class App extends React.Component {
                 <Error message="Page not found!" />
               </Route>
             </Switch>
-          </Suspense>
+          </Suspense> 
         </div>
       </Router>
     );

--- a/audino/frontend/src/components/annotate/labelButtons.js
+++ b/audino/frontend/src/components/annotate/labelButtons.js
@@ -20,7 +20,7 @@ const LabelButton = props => {
     setIsNoAudioBtnClicked(true);
     const waveSurfer = state.wavesurfer;
     const result = await waveSurfer.addRegion({id:"no audio", start:0, end:waveSurfer.getDuration()});
-    console.log("region added");
+    console.log("region added"); 
     console.log(annotate);
 
     const noAudioLabelKey = Object.keys(annotate.state.labels)[0];
@@ -32,6 +32,8 @@ const LabelButton = props => {
     console.log("no audio clicked");
     handleAllSegmentSave(annotate);
     
+    //window.location.replace('/dashboard');
+    //<Redirect to="/dashboard" /> // TODO - enter a location
     //document.getElementsByClassName("next")[0].getElementsByTagName('button')[0].click();
 
   }

--- a/audino/frontend/src/containers/navbar.js
+++ b/audino/frontend/src/containers/navbar.js
@@ -33,7 +33,9 @@ class NavBar extends React.Component {
     const { store } = this.props;
     const isUserLoggedIn = store.get('isUserLoggedIn');
     const isAdmin = store.get('isAdmin');
+    const projectId = localStorage.getItem('projectId'); // Retrieve projectId from local storage
 
+    
     return (
       <nav className="navbar navbar-expand-md bg-dark navbar-dark">
         <Link to="/" className="navbar-brand">
@@ -48,13 +50,18 @@ class NavBar extends React.Component {
         >
           <span className="navbar-toggler-icon" />
         </button>
-
+  
         {isUserLoggedIn && (
           <div className="collapse navbar-collapse" id="collapsibleNavbar">
             <ul className="navbar-nav">
               <li className="nav-item">
                 <Link className="nav-link" to="/dashboard">
                   Dashboard
+                </Link>
+              </li>
+              <li className="nav-item"> 
+                <Link className="nav-link" to={`/projects/${projectId}/data`}> 
+                  Previous Project
                 </Link>
               </li>
               {isAdmin && (

--- a/audino/frontend/src/pages/backError.js
+++ b/audino/frontend/src/pages/backError.js
@@ -1,0 +1,23 @@
+// page for when project is NULL and back button is selected
+import React from 'react';
+
+const BackError = () => {
+  return (
+    <div style={styles.container}>
+      <h1>Please Select a Project Before Attempting to Return to Previous Project</h1>
+    </div>
+  );
+};
+
+//Text allignment style
+const styles = {
+    container: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      height: '100vh',
+      textAlign: 'center'
+    }
+  };
+
+export default BackError;

--- a/audino/frontend/src/pages/data.js
+++ b/audino/frontend/src/pages/data.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom';
 
 import Loader from '../components/loader';
 
-const datas = [];
+const datas = []; 
 
 class Data extends React.Component {
   constructor(props) {
@@ -43,6 +43,7 @@ class Data extends React.Component {
   componentDidMount() {
     this.setState({ isDataLoading: true });
     this.getData();
+    localStorage.setItem('projectId', this.state.projectId); // Store projectId in local storage
     document.body.addEventListener('scroll', this.trackScrolling);
     document.body.addEventListener('scroll', () => {});
   }


### PR DESCRIPTION
Goal is to improve ease of navigation to the users previous project once they have annotated multiple data clips and want to navigate to the full list of data clips in this project. Quality of life improvement to reduce the number of clicks needed to return to the full list of cilps for the most recently worked on project. If user clicks button and has no previous project, an error message appears.